### PR TITLE
Fixes while toying around default values

### DIFF
--- a/Pragma/DB/DB.php
+++ b/Pragma/DB/DB.php
@@ -130,7 +130,7 @@ class DB{
 				while ($data = $this->fetchrow($res)) {
 					$description[] = [
 						'field'     => $data['name'],
-						'default'   => $data['dflt_value'],
+						'default'   => current(str_getcsv($data['dflt_value'], ",", "'")),
 						'null'      => !$data['notnull'],
 					];
 				}

--- a/Pragma/DB/DB.php
+++ b/Pragma/DB/DB.php
@@ -118,9 +118,9 @@ class DB{
 
 				while ($data = $this->fetchrow($res)) {
 					$description[] = [
-						'field'         => $data['Field'],
-						'default'       => $data['Default'],
-						'null'          => $data['Null'] != 'NO',
+						'field'     => $data['Field'],
+						'default'   => $data['Default'],
+						'null'      => $data['Null'] != 'NO',
 					];
 				}
 				break;
@@ -129,9 +129,9 @@ class DB{
 
 				while ($data = $this->fetchrow($res)) {
 					$description[] = [
-						'field'         => $data['name'],
-						'default'       => $data['dflt_value'],
-						'null'          => !$data['notnull'],
+						'field'     => $data['name'],
+						'default'   => $data['dflt_value'],
+						'null'      => !$data['notnull'],
 					];
 				}
 				break;

--- a/Pragma/ORM/Model.php
+++ b/Pragma/ORM/Model.php
@@ -176,7 +176,7 @@ class Model extends QueryBuilder implements SerializableInterface{
 
 		if (empty(self::$table_desc[$this->table])) {
 			foreach ($db->describe($this->table) as $data) {
-				if (empty($data['default']) && !$data['null']) {
+				if ($data['default'] === null && !$data['null']) {
 					self::$table_desc[$this->table][$data['field']] = '';
 				} else {
 					self::$table_desc[$this->table][$data['field']] = $data['default'];


### PR DESCRIPTION
i.e: empty() would trigger for "0" string

Convert only explicit NULL default values, on a non-null field to an
empty string.