### PR TITLE
Add `dev-master` stability to composer install

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ For a project skeleton using this module, see: https://github.com/pragma-framewo
 
 ### Using composer
 
-	$ composer require pragma-framework/core
+	$ composer require pragma-framework/core:dev-master


### PR DESCRIPTION
As long as we have no stable versions, give install instructions using `dev-master` composer  stability.