### PR TITLE
Fix travis test & add method chaining capabilities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ php:
   - '7.0'
   - '7.1'
   - hhvm
-  - nightly
 install: composer install
 script:
   - vendor/bin/phpunit --bootstrap ./tests/bootstrap.config.sqlite.php tests/

--- a/Pragma/ORM/Model.php
+++ b/Pragma/ORM/Model.php
@@ -110,6 +110,8 @@ class Model extends QueryBuilder implements SerializableInterface{
 
 	public function merge($data){
 		$this->fields = array_merge($this->fields, $data);
+
+		return $this;
 	}
 
 
@@ -159,6 +161,8 @@ class Model extends QueryBuilder implements SerializableInterface{
 
 			$db->query($sql, $values);
 		}
+
+		return $this;
 	}
 
 	public function toJSON(){


### PR DESCRIPTION
We can't build against php-nightly anymore because of old PHPUnit dependency, to fix these and enable php-nightly again, we need to upgrade PHPUnit version.

Aside, the second patch allows method chaining from Model::save() & Model::merge() as proposed in #15.

ok?