### PR TITLE
Fix request urldecode & return/break after Exception

### DIFF
--- a/Pragma/DB/DB.php
+++ b/Pragma/DB/DB.php
@@ -98,12 +98,10 @@ class DB{
 			}
 			else{
 				throw new DBException('PDO attribute is undefined');
-				return null;
 			}
 		}
 		catch(\Exception $e){
 			throw new DBException($e->getMessage(), $e->getCode());
-			return null;
 		}
 	}
 
@@ -234,7 +232,7 @@ class DB{
 			}
 		}
 		else{
-				throw new \Exception("getPDOParamsFor : Params should be an array");
+			throw new \Exception("getPDOParamsFor : Params should be an array");
 		}
 	}
 }

--- a/Pragma/ORM/Model.php
+++ b/Pragma/ORM/Model.php
@@ -66,7 +66,6 @@ class Model extends QueryBuilder implements SerializableInterface, \JsonSerializ
 
 		if($error){
 			throw new \Exception("Error getting an instance of ".get_class($this)." - PK Error", 1);
-
 		}
 	}
 
@@ -128,7 +127,6 @@ class Model extends QueryBuilder implements SerializableInterface, \JsonSerializ
 			foreach($pk as $k => $val){
 				if( ! isset($mypks[$k]) ){
 					throw new \Exception("Error opening the instance of ".get_class($this)." - unknown PK column", 1);
-					break;
 				}
 				if( $i > 1 ){
 					$sql .= " AND ";
@@ -167,7 +165,6 @@ class Model extends QueryBuilder implements SerializableInterface, \JsonSerializ
 			foreach($pk as $k => $val){
 				if( ! isset($mypks[$k]) ){
 					throw new \Exception("Error opening the instance of ".get_class($o)." - unknown PK column", 1);
-					break;
 				}
 				$qb->where($k, '=', $val);
 			}

--- a/Pragma/Router/Request.php
+++ b/Pragma/Router/Request.php
@@ -38,7 +38,7 @@ class Request{
 
 			$this->method = 'cli';
 		}else{
-			$this->path = parse_url(trim(isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : '/'), PHP_URL_PATH);
+			$this->path = urldecode(parse_url(trim(isset($_SERVER['REQUEST_URI']) ? $_SERVER['REQUEST_URI'] : '/'), PHP_URL_PATH));
 
 			$this->method = strtolower($_SERVER['REQUEST_METHOD']);
 


### PR DESCRIPTION
Remove return & break after `throw new Exception()`.

Add `urldecode` on Request::__construct() (not cli):
- url > http://domain/url/%5Ctest%5Ctest
- router > /url/:dynparam
- without urldecode: dynparam = '%5Ctest%5Ctest'
- with urldecode: dynparam = '\test\test'
