### PR TITLE
Feature/add cli

### DIFF
--- a/Pragma/Console/Application.php
+++ b/Pragma/Console/Application.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Pragma\Console;
+
+use AtlantisPHP\Console\Application as Console;
+
+class Application
+{
+  /**
+   * Return console application
+   *
+   * @return Void
+   */
+  public static function boot()
+  {
+    $application = new Console('Pragma Console');
+
+    $application->load(__DIR__ . '/Commands');
+
+    $application->run();
+  }
+}

--- a/Pragma/Console/Commands/Serve.php
+++ b/Pragma/Console/Commands/Serve.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Pragma\Console\Commands;
+
+use AtlantisPHP\Console\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Serve extends Command
+{
+  /**
+   * The name and signature of the console command.
+   *
+   * @var string
+   */
+  protected $signature = 'serve {port=8000}';
+
+  /**
+   * The full command description.
+   *
+   * @var string
+   */
+  protected $help = 'This command allows you to serve your Application';
+
+  /**
+   * The descriptions of the console commands.
+   *
+   * @var array
+   */
+  protected $descriptions = [
+    'serve' => 'Serve the application on the PHP development serve',
+    'port' => 'The port to serve the application on'
+  ];
+
+  /**
+   * @param InputInterface  $input
+   * @param OutputInterface $output
+   *
+   * @return void
+   */
+  protected function execute(InputInterface $input, OutputInterface $output)
+  {
+    $appPath = str_replace('vendor/pragma-framework/core/Pragma/Console/Commands', '', __DIR__);
+
+    /**
+     * Get Port
+     */
+    $port = $input->getOption('port');
+
+    /**
+     * Check if Port is numeric
+     */
+    if (!is_numeric($port)) return $output->writeln('Invalid port number');
+
+    /**
+     * Alert the userr
+     */
+    $output->writeln("<info>Running Pragma application on</info> http://localhost:{$port}");
+
+    /**
+     * Serve application
+     */
+    passthru('php -S localhost:' . $port . ' -t ' . $appPath . '/public');
+  }
+
+}

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
     ],
     "require": {
         "php": ">=7.0",
-        "ext-PDO": "^7.0"
+        "ext-PDO": "^7.0",
+        "atlantisphp/console": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "4.8",


### PR DESCRIPTION
# Feature

This PR adds a console application to the Pragma Framework. Commands are stored in the `Pragma/Console/Commands` folder and loaded by the `Pragma\Console\Application` class.

### CLI Implementation

In order for the CLI to work, you will need to create a new `pragma` file in the root level of [pragma-framework/framework](https://github.com/pragma-framework/framework).

The basic code implementation should look like:
```php
#!/usr/bin/env php
<?php

require_once __DIR__. '/vendor/autoload.php';// Autoload our dependencies with Composer

use Pragma\Console\Application;

Application::boot();
```

Save and run the cli:
```bash
php pragma
```

Screenshot
<img src="https://i.imgur.com/LuLPf3u.png">