### PR TITLE
Evo on where/join & syntax

### DIFF
--- a/Pragma/ORM/QueryBuilder.php
+++ b/Pragma/ORM/QueryBuilder.php
@@ -309,7 +309,9 @@ class QueryBuilder{
 				if(strpos(trim($join['table']), ' ') !== false){
 					$join['table'] = explode(' ',$join['table']);
 					if(count($join['table']) == 2){
-						$join['table'] = $e.$join['table'][0]."$e ".$join['table'][1];
+						$join['table'] = $e.$join['table'][0]."$e AS ".$join['table'][1];
+					}elseif(count($join['table']) == 3 && strtolower($join['table'][1]) == 'as'){
+						$join['table'] = $e.$join['table'][0]."$e AS ".$join['table'][2];
 					}else{
 						$join['table'] = implode(' ',$join['table']);
 					}

--- a/Pragma/ORM/QueryBuilder.php
+++ b/Pragma/ORM/QueryBuilder.php
@@ -320,13 +320,30 @@ class QueryBuilder{
 				}
 
 				$query .= ' ' . $join['type'] . ' JOIN ' . $join['table']. ' ON ';
-				if(strpos(trim($join['on'][0]), '.') !== false){
-					$join['on'][0] = implode("$e.$e",explode('.',trim($join['on'][0])));
+				if (is_array($join['on'][0])) {
+					$first = true;
+					foreach ($join['on'] as $on) {
+						if (! is_array($on)) {
+							throw new \Exception("Join can't be created, 'on' must be an array");
+						}
+						if (strpos(trim($on[0]), '.') !== false) {
+							$on[0] = implode("$e.$e", explode('.', trim($on[0])));
+						}
+						if (strpos(trim($on[2]), '.') !== false) {
+							$on[2] = $e.implode("$e.$e", explode('.', trim($on[2]))).$e;
+						}
+						$query .= ($first ? '' : ' AND ').$e . $on[0] . "$e " . $on[1] . ' ' . $on[2].' ';
+						$first = false;
+					}
+				} else {
+					if(strpos(trim($join['on'][0]), '.') !== false){
+						$join['on'][0] = implode("$e.$e",explode('.',trim($join['on'][0])));
+					}
+					if(strpos(trim($join['on'][2]), '.') !== false){
+						$join['on'][2] = $e.implode("$e.$e",explode('.',trim($join['on'][2]))).$e;
+					}
+					$query .= $e . $join['on'][0] . "$e " . $join['on'][1] . ' ' . $join['on'][2];
 				}
-				if(strpos(trim($join['on'][2]), '.') !== false){
-					$join['on'][2] = $e.implode("$e.$e",explode('.',trim($join['on'][2]))).$e;
-				}
-				$query .= $e . $join['on'][0] . "$e " . $join['on'][1] . ' ' . $join['on'][2];
 			}
 		}
 

--- a/Pragma/ORM/QueryBuilder.php
+++ b/Pragma/ORM/QueryBuilder.php
@@ -61,7 +61,7 @@ class QueryBuilder{
 		return $this;
 	}
 
-	public function subwhere($subcallback, $bool = "and"){
+	public function subwhere($subcallback, $bool = "AND"){
 		array_push($this->current_subs, ["subs" => [], "bool" => $bool]);
 		$subcallback($this);
 		$sub = array_pop($this->current_subs);
@@ -84,9 +84,9 @@ class QueryBuilder{
 		return $this;
 	}
 
-	public function order($columns, $way = 'asc'){
+	public function order($columns, $way = 'ASC'){
 		if( ! empty($columns) ){
-			$this->order = " ORDER BY " . $columns . " " . $way;
+			$this->order = " ORDER BY " . $columns . " " . strtoupper($way);
 		}
 		return $this;
 	}
@@ -108,7 +108,7 @@ class QueryBuilder{
 		return $this;
 	}
 
-	public function join($table, $on, $type = 'inner' ){
+	public function join($table, $on, $type = 'INNER' ){
 		array_push($this->joins, ['table' => $table, 'on' => $on, 'type' => $type]);
 		return $this;
 	}
@@ -367,7 +367,7 @@ class QueryBuilder{
 	private function build_where($cond, &$query, &$params, &$counter_params, $first = true){
 		if(isset($cond['cond'])){// We are on a real WHERE clause
 			if( ! $first ){
-				$query .= " ".$cond['bool']." ";
+				$query .= " ".strtoupper($cond['bool'])." ";
 			}
 
 			$e = $this->escape ? self::$escapeChar : "";
@@ -434,7 +434,7 @@ class QueryBuilder{
 		}
 		else if(isset($cond['subs'])){//sub conditions
 			if( ! $first ){
-				$query .= " ".$cond['bool']." ";
+				$query .= " ".strtoupper($cond['bool'])." ";
 			}
 
 			$query .= ' ( ';

--- a/Pragma/ORM/QueryBuilder.php
+++ b/Pragma/ORM/QueryBuilder.php
@@ -320,29 +320,22 @@ class QueryBuilder{
 				}
 
 				$query .= ' ' . $join['type'] . ' JOIN ' . $join['table']. ' ON ';
-				if (is_array($join['on'][0])) {
-					$first = true;
-					foreach ($join['on'] as $on) {
-						if (! is_array($on)) {
-							throw new \Exception("Join can't be created, 'on' must be an array");
-						}
-						if (strpos(trim($on[0]), '.') !== false) {
-							$on[0] = implode("$e.$e", explode('.', trim($on[0])));
-						}
-						if (strpos(trim($on[2]), '.') !== false) {
-							$on[2] = $e.implode("$e.$e", explode('.', trim($on[2]))).$e;
-						}
-						$query .= ($first ? '' : ' AND ').$e . $on[0] . "$e " . $on[1] . ' ' . $on[2].' ';
-						$first = false;
+				if (!is_array($join['on'][0])) {
+					$join['on'] = [$join['on']];
+				}
+				$first = true;
+				foreach ($join['on'] as $on) {
+					if (! is_array($on)) {
+						throw new \Exception("Join can't be created, 'on' must be an array");
 					}
-				} else {
-					if(strpos(trim($join['on'][0]), '.') !== false){
-						$join['on'][0] = implode("$e.$e",explode('.',trim($join['on'][0])));
+					if (strpos(trim($on[0]), '.') !== false) {
+						$on[0] = implode("$e.$e", explode('.', trim($on[0])));
 					}
-					if(strpos(trim($join['on'][2]), '.') !== false){
-						$join['on'][2] = $e.implode("$e.$e",explode('.',trim($join['on'][2]))).$e;
+					if (strpos(trim($on[2]), '.') !== false) {
+						$on[2] = $e.implode("$e.$e", explode('.', trim($on[2]))).$e;
 					}
-					$query .= $e . $join['on'][0] . "$e " . $join['on'][1] . ' ' . $join['on'][2];
+					$query .= ($first ? '' : ' AND ').$e . $on[0] . "$e " . $on[1] . ' ' . $on[2].' ';
+					$first = false;
 				}
 			}
 		}

--- a/Pragma/ORM/Relation.php
+++ b/Pragma/ORM/Relation.php
@@ -36,17 +36,24 @@ class Relation{
 	}
 
 	public static function getAll($classon = null){
-		if(empty($classon)){
-			return static::$all_relations;
-		}else{
-			if(!empty(static::$progress_work[$classon])) {
-				//the relations are not all initialized, lets do that
-				foreach(static::$progress_work[$classon] as $name => $dataToInitialize) {
-					Relation::build($dataToInitialize['type'], $name, $classon, $dataToInitialize['classto'], $dataToInitialize['custom'], $dataToInitialize['onpk']);
+		$fetch = [];
+		if(empty($classon)) {
+			$fetch = static::$progress_work;
+		}
+		else if(isset(static::$progress_work[$classon])){
+			$fetch = [$classon => static::$progress_work[$classon]];
+		}
+
+
+		if(!empty($fetch)) {
+			foreach($fetch as $classonf => $data) {
+				foreach($data as $name => $dataToInitialize) {
+					Relation::build($dataToInitialize['type'], $name, $classonf, $dataToInitialize['classto'], $dataToInitialize['custom'], $dataToInitialize['onpk']);
 				}
 			}
-			return isset(static::$all_relations[$classon]) ? static::$all_relations[$classon] : [];
+			return empty($classon) ? static::$all_relations : (isset(static::$all_relations[$classon]) ? static::$all_relations[$classon] : []);
 		}
+
 		return [];
 	}
 
@@ -247,10 +254,10 @@ class Relation{
 				}
 
 				if( ! array_key_exists($this->cols['on'], $model->describe()) ){
-				 	throw new \Exception("Fetching relation - unknown column 'on' : ".$this->cols['on']." in source model ".get_class($model));
+					throw new \Exception("Fetching relation - unknown column 'on' : ".$this->cols['on']." in source model ".get_class($model));
 				}
 				if( ! array_key_exists($this->cols['to'], $remote->describe()) ){
-				 	throw new \Exception("Fetching relation - unknown column 'to' : ".$this->cols['to']." in remote model ".get_class($remote));
+					throw new \Exception("Fetching relation - unknown column 'to' : ".$this->cols['to']." in remote model ".get_class($remote));
 				}
 				$on = $this->cols['on'];
 				$qb->where($this->cols['to'], '=', $model->$on);

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -78,7 +78,7 @@ class QueryBuilderTest extends \PHPUnit\DbUnit\TestCase
 			}elseif(DB_CONNECTOR == 'pgsql' || DB_CONNECTOR == 'postgresql'){
 				// $this->db->query('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"');
 				$suid = 'uuid_generate_v4()';
-				// $suid = 'gen_random_uuid()';
+				// $suid = 'gen_rANDom_uuid()';
 			}
 			$uuidRS = $this->db->query('SELECT '.$suid.' as uuid');
 			$uuidRes = $this->db->fetchrow($uuidRS);
@@ -223,8 +223,8 @@ class QueryBuilderTest extends \PHPUnit\DbUnit\TestCase
 		});
 
 		$this->assertEquals([[
-			'subs' => [['cond' => ['id', '=', $this->defaultDatas['testtable'][1]['id']], 'bool' => 'and']],
-			'bool' => 'and'
+			'subs' => [['cond' => ['id', '=', $this->defaultDatas['testtable'][1]['id']], 'bool' => 'AND', 'use_pdo' => true]],
+			'bool' => 'AND'
 		]], \PHPUnit\Framework\Assert::readAttribute($this->queryBuilder, 'where'));
 
 		$this->queryBuilder->subwhere(function($queryBuilder) {
@@ -232,11 +232,11 @@ class QueryBuilderTest extends \PHPUnit\DbUnit\TestCase
 		}, 'booz');
 
 		$this->assertEquals([[
-			'subs' => [['cond' => ['id', '=', $this->defaultDatas['testtable'][1]['id']], 'bool' => 'and']],
-			'bool' => 'and'
+			'subs' => [['cond' => ['id', '=', $this->defaultDatas['testtable'][1]['id']], 'bool' => 'AND', 'use_pdo' => true]],
+			'bool' => 'AND'
 		],
 		[
-			'subs' => [['cond' => ['foo', 'bar', 'baz'], 'bool' => 'boo']],
+			'subs' => [['cond' => ['foo', 'bar', 'baz'], 'bool' => 'boo', 'use_pdo' => true]],
 			'bool' => 'booz'
 		]], \PHPUnit\Framework\Assert::readAttribute($this->queryBuilder, 'where'));
 
@@ -246,17 +246,17 @@ class QueryBuilderTest extends \PHPUnit\DbUnit\TestCase
 		}, 'or');
 
 		$this->assertEquals([[
-			'subs' => [['cond' => ['id', '=', $this->defaultDatas['testtable'][1]['id']], 'bool' => 'and']],
-			'bool' => 'and'
+			'subs' => [['cond' => ['id', '=', $this->defaultDatas['testtable'][1]['id']], 'bool' => 'AND', 'use_pdo' => true]],
+			'bool' => 'AND'
 		],
 		[
-			'subs' => [['cond' => ['foo', 'bar', 'baz'], 'bool' => 'boo']],
+			'subs' => [['cond' => ['foo', 'bar', 'baz'], 'bool' => 'boo', 'use_pdo' => true]],
 			'bool' => 'booz'
 		],
 		[
 			'subs' => [
-				['cond' => ['value', '=', 'xyz'], 'bool' => 'AND'],
-				['cond' => ['id', '>', $this->defaultDatas['testtable'][1]['id']], 'bool' => 'OR']
+				['cond' => ['value', '=', 'xyz'], 'bool' => 'AND', 'use_pdo' => true],
+				['cond' => ['id', '>', $this->defaultDatas['testtable'][1]['id']], 'bool' => 'OR', 'use_pdo' => true]
 			],
 			'bool' => 'or'
 		]], \PHPUnit\Framework\Assert::readAttribute($this->queryBuilder, 'where'));
@@ -267,22 +267,22 @@ class QueryBuilderTest extends \PHPUnit\DbUnit\TestCase
 		$this->queryBuilder->where('value', '=', 'foo');
 
 		$this->assertEquals([
-			[ 'cond' => ['value', '=', 'foo'], 'bool' => 'and'],
+			[ 'cond' => ['value', '=', 'foo'], 'bool' => 'AND', 'use_pdo' => true],
 		], \PHPUnit\Framework\Assert::readAttribute($this->queryBuilder, 'where'));
 
 		$this->queryBuilder->where('bar', 'baz', 'foo', 'boo');
 
 		$this->assertEquals([
-			[ 'cond' => ['value',   '=',    'foo'], 'bool' => 'and'],
-			[ 'cond' => ['bar',     'baz',  'foo'], 'bool' => 'boo'],
+			[ 'cond' => ['value',   '=',    'foo'], 'bool' => 'AND', 'use_pdo' => true],
+			[ 'cond' => ['bar',     'baz',  'foo'], 'bool' => 'boo', 'use_pdo' => true],
 		], \PHPUnit\Framework\Assert::readAttribute($this->queryBuilder, 'where'));
 
 		$this->queryBuilder->where('id', '>', $this->defaultDatas['testtable'][2]['id'], 'or');
 
 		$this->assertEquals([
-			[ 'cond' => ['value',   '=',    'foo'], 'bool' => 'and'],
-			[ 'cond' => ['bar',     'baz',  'foo'], 'bool' => 'boo'],
-			[ 'cond' => ['id',      '>',    $this->defaultDatas['testtable'][2]['id']],   'bool' => 'or'],
+			[ 'cond' => ['value',   '=',    'foo'], 'bool' => 'AND', 'use_pdo' => true],
+			[ 'cond' => ['bar',     'baz',  'foo'], 'bool' => 'boo', 'use_pdo' => true],
+			[ 'cond' => ['id',      '>',    $this->defaultDatas['testtable'][2]['id']],   'bool' => 'or', 'use_pdo' => true],
 		], \PHPUnit\Framework\Assert::readAttribute($this->queryBuilder, 'where'));
 	}
 
@@ -290,15 +290,15 @@ class QueryBuilderTest extends \PHPUnit\DbUnit\TestCase
 	{
 		$this->queryBuilder->order('id');
 
-		$this->assertEquals(' ORDER BY id asc', \PHPUnit\Framework\Assert::readAttribute($this->queryBuilder, 'order'));
+		$this->assertEquals(' ORDER BY id ASC', \PHPUnit\Framework\Assert::readAttribute($this->queryBuilder, 'order'));
 
 		$this->queryBuilder->order('foo', 'bar');
 
-		$this->assertEquals(' ORDER BY foo bar', \PHPUnit\Framework\Assert::readAttribute($this->queryBuilder, 'order'));
+		$this->assertEquals(' ORDER BY foo BAR', \PHPUnit\Framework\Assert::readAttribute($this->queryBuilder, 'order'));
 
 		$this->queryBuilder->order('value', 'desc');
 
-		$this->assertEquals(' ORDER BY value desc', \PHPUnit\Framework\Assert::readAttribute($this->queryBuilder, 'order'));
+		$this->assertEquals(' ORDER BY value DESC', \PHPUnit\Framework\Assert::readAttribute($this->queryBuilder, 'order'));
 
 	}
 
@@ -355,20 +355,20 @@ class QueryBuilderTest extends \PHPUnit\DbUnit\TestCase
 		$this->queryBuilder->join('anothertable', ['anothertable.testtable_id', '=', 'testtable.id']);
 
 		$this->assertEquals([
-			[ 'table' => 'anothertable', 'on' => ['anothertable.testtable_id', '=', 'testtable.id'], 'type' => 'inner'],
+			[ 'table' => 'anothertable', 'on' => ['anothertable.testtable_id', '=', 'testtable.id'], 'type' => 'INNER'],
 		], \PHPUnit\Framework\Assert::readAttribute($this->queryBuilder, 'joins'));
 
 		$this->queryBuilder->join('foo', ['bar', 'baz', 'abc'], 'def');
 
 		$this->assertEquals([
-			[ 'table' => 'anothertable', 'on' => ['anothertable.testtable_id', '=', 'testtable.id'], 'type' => 'inner'],
+			[ 'table' => 'anothertable', 'on' => ['anothertable.testtable_id', '=', 'testtable.id'], 'type' => 'INNER'],
 			[ 'table' => 'foo', 'on' => ['bar', 'baz', 'abc'], 'type' => 'def'],
 		], \PHPUnit\Framework\Assert::readAttribute($this->queryBuilder, 'joins'));
 
 		$this->queryBuilder->join('anothertable', ['testtable.id', '=', 'anothertable.testtable_id'], 'left');
 
 		$this->assertEquals([
-			[ 'table' => 'anothertable', 'on' => ['anothertable.testtable_id', '=', 'testtable.id'], 'type' => 'inner'],
+			[ 'table' => 'anothertable', 'on' => ['anothertable.testtable_id', '=', 'testtable.id'], 'type' => 'INNER'],
 			[ 'table' => 'foo', 'on' => ['bar', 'baz', 'abc'], 'type' => 'def'],
 			[ 'table' => 'anothertable', 'on' => ['testtable.id', '=', 'anothertable.testtable_id'], 'type' => 'left'],
 		], \PHPUnit\Framework\Assert::readAttribute($this->queryBuilder, 'joins'));


### PR DESCRIPTION
Add param $usePDO in where()
```php
$qb->where('table1.id', '=', 'table2.id', 'and', false);
```
generate
```sql
WHERE `table1`.`id` = table2.id
```
---

Fix using `AS` on $table param in join()
```php
$qb->join('table1 as t');
```
generate
```sql
INNER JOIN `table1` AS t
instead of
```sql
INNER JOIN table1 as t
```

---

Evo on $on param in join()
```php
$qb->join('table1 as t', [
['id', '=', 'id2'],
['id3', '=', 'id4'],
]);
```
generate
```sql
INNER JOIN `table1` AS t
ON `id` = `id2`
AND `id3` = `id4`
```