### PR TITLE
check relation column value for prevent null/empty array access

### DIFF
--- a/Pragma/ORM/Relation.php
+++ b/Pragma/ORM/Relation.php
@@ -380,7 +380,10 @@ class Relation{
 				$on = $this->cols['on'];
 				foreach($models as $m){
 					$val = $type == 'objects' ? $m->$on : $m[$on];
-					$refs[$val] = $val;
+					// Check if column $on has a value to prevent null/empty values
+					if ($val) {
+						$refs[$val] = $val;
+					}
 				}
 
 				if( ! empty($refs) ){
@@ -405,7 +408,7 @@ class Relation{
 					foreach($models as &$m){
 						$ref = $type == 'objects' ? $m->$on : $m[$on];
 
-						if(isset($pairing[$ref])){
+						if($ref && isset($pairing[$ref])){
 							if($type == 'objects'){
 								$m->add_inclusion($this->name, $this->type == 'has_many' ? $pairing[$ref] : current($pairing[$ref]));
 							}

--- a/Pragma/ORM/Relation.php
+++ b/Pragma/ORM/Relation.php
@@ -381,7 +381,7 @@ class Relation{
 				foreach($models as $m){
 					$val = $type == 'objects' ? $m->$on : $m[$on];
 					// Check if column $on has a value to prevent null/empty values
-					if ($val) {
+					if ($val !== null) {
 						$refs[$val] = $val;
 					}
 				}
@@ -408,7 +408,7 @@ class Relation{
 					foreach($models as &$m){
 						$ref = $type == 'objects' ? $m->$on : $m[$on];
 
-						if($ref && isset($pairing[$ref])){
+						if($ref !== null && isset($pairing[$ref])){
 							if($type == 'objects'){
 								$m->add_inclusion($this->name, $this->type == 'has_many' ? $pairing[$ref] : current($pairing[$ref]));
 							}


### PR DESCRIPTION
Using null as an array offset is deprecated with php 8.5